### PR TITLE
feat(person): person 조회 API 추가

### DIFF
--- a/main/__init__.py
+++ b/main/__init__.py
@@ -44,9 +44,10 @@ CORS(app)
 
 # blueprint 추가
 from main.controllers.auth import auth_bp
+from main.controllers.cdm import cdm_bp
 from main.controllers import skeleton_bp
 
-blueprints = [auth_bp, skeleton_bp]
+blueprints = [auth_bp, cdm_bp, skeleton_bp]
 
 for bp in blueprints:
   app.register_blueprint(bp)
@@ -58,5 +59,3 @@ for key, value in docs.spec._paths.items():
   docs.spec._paths[key] = {
       inner_key: inner_value for inner_key, inner_value in value.items() if inner_key != "options"
   }
-
-db.create_all()  # DB 없으면 생성

--- a/main/controllers/cdm/__init__.py
+++ b/main/controllers/cdm/__init__.py
@@ -1,6 +1,6 @@
 from flask import Blueprint
 
-auth_bp = Blueprint("cdm", __name__, url_prefix="/cdm_api")
+cdm_bp = Blueprint("cdm", __name__, url_prefix="/cdm_api")
 
 API_CATEGORY = "Cdm"
 

--- a/main/controllers/cdm/person.py
+++ b/main/controllers/cdm/person.py
@@ -1,0 +1,120 @@
+from main.models.utils import convert_query_to_response
+from flask_apispec import marshal_with, doc
+# main에서 cdm 호출 후 cdm에서 person 호출
+from main.controllers.cdm import cdm_bp, API_CATEGORY
+from main import db
+from main.schema.cdm_schema import (
+    PersonCount,
+    ResponseConceptPersonCount,
+    ResponseSourcePersonCount
+)
+from main.models.cdm_data import Death, Person
+
+@cdm_bp.route("/person", methods=["GET"])
+@doc(tags=[API_CATEGORY],
+     summary="컬럼 설명",
+     description="환자 수 조회를 위한 파라미터를 설명합니다.")
+def index():
+  return ({
+      "all": "모든 환자 수",
+      "gender": "성별 환자 수",
+      "race": "인종별 환자 수",
+      "ethnicity": "민족별 환자 수",
+      "death": "사망 환자 수"
+  }, 200)
+
+
+@cdm_bp.route("/person/all", methods=["GET"])
+@marshal_with(PersonCount, description="""
+<pre>
+person_count: 전체 환자 수
+</pre>
+""")
+@doc(tags=[API_CATEGORY],
+     summary="전체 환자 수 조회",
+     description="전체 환자 수를 조회합니다.")
+def all_count():
+  return {
+      "person_count": db.session.query(Person).count()
+  }
+
+
+@cdm_bp.route("/person/gender", methods=["GET"])
+@doc(tags=[API_CATEGORY],
+     summary="성별 환자 수 조회",
+     description="성별 환자 수를 조회합니다.")
+@marshal_with(ResponseConceptPersonCount("person_list"),
+              description="""
+<pre>
+person_list: 환자 수 정보가 들어갈 리스트
+  .concept_id: 성별 Concept ID
+  .concept_name: 성별 Concept 이름
+  .person_count: 환자 수
+</pre>
+""")
+def gender_count():
+  query = Person.person_gorup_by_condtion("gender_concept_id")
+  return {
+      "person_list": convert_query_to_response(
+          ("concept_id", "concept_name", "person_count"),
+          query.all()
+      )
+  }
+
+
+@cdm_bp.route("/person/race", methods=["GET"])
+@doc(tags=[API_CATEGORY],
+     summary="인종별 환자 수 조회",
+     description="인종별 환자 수를 조회합니다.")
+@marshal_with(ResponseConceptPersonCount("person_list"), description="""
+<pre>
+person_list: 환자 수 정보가 들어갈 리스트
+  .concept_id: 인종별 Concept ID
+  .concept_name: 인종별 Concept 이름
+  .person_count: 환자 수
+</pre>
+""")
+def race_count():
+  query = Person.person_gorup_by_condtion("race_concept_id")
+  return {
+      "person_list": convert_query_to_response(
+          ("concept_id", "concept_name", "person_count"),
+          query.all()
+      )
+  }
+
+
+@cdm_bp.route("/person/ethnicity", methods=["GET"])
+@doc(tags=[API_CATEGORY],
+     summary="민족별 환자 수 조회",
+     description="민족별 환자 수를 조회합니다.")
+@marshal_with(ResponseSourcePersonCount("person_list"), description="""
+<pre>
+person_list: 환자 수 정보가 들어갈 리스트
+  .source_value: 민족별 Source Value
+  .person_count: 환자 수
+</pre>
+""")
+def ethnicity_count():
+  query = Person.person_group_by_ethnicity()
+  return {
+      "person_list": convert_query_to_response(
+          ("source_value", "person_count"),
+          query.all()
+      )
+  }
+
+
+@cdm_bp.route("/person/death", methods=["GET"])
+@doc(tags=[API_CATEGORY],
+     summary="사망 환자 수 조회",
+     description="사망 환자 수를 조회합니다.")
+@marshal_with(PersonCount, description="""
+<pre>
+person_count: 사망 환자 수
+</pre>
+""")
+def death_count():
+  return {
+      "person_count": db.session.query(Death).count()
+  }

--- a/main/controllers/cdm/person.py
+++ b/main/controllers/cdm/person.py
@@ -10,6 +10,7 @@ from main.schema.cdm_schema import (
 )
 from main.models.cdm_data import Death, Person
 
+
 @cdm_bp.route("/person", methods=["GET"])
 @doc(tags=[API_CATEGORY],
      summary="컬럼 설명",

--- a/main/controllers/cdm/person.py
+++ b/main/controllers/cdm/person.py
@@ -96,6 +96,11 @@ person_list: 환자 수 정보가 들어갈 리스트
 </pre>
 """)
 def ethnicity_count():
+  """
+  ethnicitiy_concept_id의 모든 값이 0이다.
+  concept 테이블을 조회하니 유효하지 않는 값이라고 나온다.
+  부득이하게 대체 값인 ethnicity_source_value를 사용한다.
+  """
   query = Person.person_group_by_ethnicity()
   return {
       "person_list": convert_query_to_response(

--- a/main/models/utils.py
+++ b/main/models/utils.py
@@ -1,0 +1,5 @@
+def convert_query_to_response(attrs, elems):
+  if isinstance(elems, list):
+    return [{attr: col for attr, col in zip(attrs, elem)} for elem in elems]
+  else:
+    return {attr: col for attr, col in zip(attrs, elems)}

--- a/main/schema/cdm_schema.py
+++ b/main/schema/cdm_schema.py
@@ -1,0 +1,45 @@
+from marshmallow import fields, Schema
+
+
+# Response
+class PersonCount(Schema):
+  person_count = fields.Int(description="환자 수")
+
+
+class Concept(Schema):
+  concept_id = fields.Int(description="Concept ID")
+  concept_name = fields.Str(description="Concept 이름")
+
+
+class Source(Schema):
+  source_value = fields.Str(description="Source Value")
+
+
+class ConceptPersonCount(Concept, PersonCount):
+  pass
+
+
+class SourcePersonCount(Source, PersonCount):
+  pass
+
+
+def create_nested_list_schema(root_name, schema, name):
+  return Schema.from_dict({
+      root_name: fields.List(fields.Nested(schema))
+  }, name=name)
+
+
+def create_concept_person_count_list_schema(root_name):
+  schema_name = root_name.split("_")[0].capitalize()
+  schema_name = f"Response{schema_name}PersonCount"
+  return create_nested_list_schema(root_name, ConceptPersonCount, schema_name)
+
+
+def create_source_person_count_list_schema(root_name):
+  schema_name = root_name.split("_")[0].capitalize()
+  schema_name = f"Response{schema_name}PersonCount"
+  return create_nested_list_schema(root_name, SourcePersonCount, schema_name)
+
+
+ResponseConceptPersonCount = create_concept_person_count_list_schema
+ResponseSourcePersonCount = create_source_person_count_list_schema


### PR DESCRIPTION
다음의 기능을 지원하는 person controller를 추가했습니다.
 - 사용 가능한 URL 조회 (GET /api/person)
 - 전체 환자 수 조회 (GET /api/person/all)
 - 성별 환자 수 조회 (GET /api/person/gender)
 - 인종별 환자 수 조회 (GET /api/person/race)
 - 민족별 환자 수 조회 (GET /api/person/ethnicity)
 - 사망 환자 수 조회 (GET /api/person/death)
 
현재 민족별 조회를 위한 ethnicity_concept_id가 유효하지 않은 것으로 보입니다.
따라서 민족별 환자 수 조회를 위해 부득이하게 ethnicity_source_value를 사용하였습니다.