### PR TITLE
feat(visit): visit 조회 API 추가

### DIFF
--- a/main/__init__.py
+++ b/main/__init__.py
@@ -1,16 +1,15 @@
 
 import os
 from datetime import timedelta  # 산술 연산이 가능한 date 객체
-from flask import Flask  # Falsk 2.0.0부터는 FlaskApiSpec이 동작하지 않는다. v1.1.2를 사용했다.
-from flask_cors import CORS
-from flask_sqlalchemy import SQLAlchemy
-from flask_compress import Compress
-from flask_jwt_extended import JWTManager
-
 # swagger, OpenAPI 명세 작성
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
+from flask import Flask  # Falsk 2.0.0부터는 FlaskApiSpec이 동작하지 않는다. v1.1.2를 사용했다.
 from flask_apispec.extension import FlaskApiSpec
+from flask_compress import Compress
+from flask_cors import CORS
+from flask_sqlalchemy import SQLAlchemy
+from flask_jwt_extended import JWTManager
 
 app = Flask(__name__)
 base_dir = os.getcwd()
@@ -43,12 +42,12 @@ jwt = JWTManager(app)
 CORS(app)
 
 # blueprint 추가
-from main.controllers.auth import auth_bp
-from main.controllers.cdm import cdm_bp
 from main.controllers import skeleton_bp
+from main.controllers.auth import auth_bp
+from main.controllers.cdm import cdm_bps
 
 blueprints = [auth_bp, skeleton_bp]
-blueprints.extend(cdm_bp)
+blueprints.extend(cdm_bps)
 
 for bp in blueprints:
   app.register_blueprint(bp)

--- a/main/__init__.py
+++ b/main/__init__.py
@@ -47,7 +47,8 @@ from main.controllers.auth import auth_bp
 from main.controllers.cdm import cdm_bp
 from main.controllers import skeleton_bp
 
-blueprints = [auth_bp, cdm_bp, skeleton_bp]
+blueprints = [auth_bp, skeleton_bp]
+blueprints.extend(cdm_bp)
 
 for bp in blueprints:
   app.register_blueprint(bp)

--- a/main/controllers/auth/user.py
+++ b/main/controllers/auth/user.py
@@ -1,20 +1,13 @@
-from os import access
-from flask_apispec import use_kwargs, marshal_with, doc
+from flask_apispec import doc, marshal_with, use_kwargs
 from flask_jwt_extended import (
-    jwt_required,
-    get_jwt_identity,
     create_access_token,
-    get_jwt
+    get_jwt,
+    get_jwt_identity,
+    jwt_required
 )
 # main에서 auth 호출 후 auth에서 user 호출
-from main.controllers.auth import auth_bp, API_CATEGORY, authorization_header
 from main import app, db, jwt
-from main.schema import (
-    ResponseLoginSchema,
-    RequestLoginSchema,
-    ResponseAccessTokenSchema
-)
-from main.models.user import User, TokenBlacklist
+from main.controllers.auth import API_CATEGORY, auth_bp, authorization_header
 from main.models.common.message import (
     ResponseMessage,
     ERROR_NULL_EMAIL,
@@ -25,6 +18,12 @@ from main.models.common.message import (
     ERROR_USER_NOT_EXISTS,
     SUCCESS_SIGNUP,
     SUCCESS_LOGOUT
+)
+from main.models.user import User, TokenBlacklist
+from main.schema import (
+    ResponseLoginSchema,
+    RequestLoginSchema,
+    ResponseAccessTokenSchema
 )
 
 

--- a/main/controllers/cdm/__init__.py
+++ b/main/controllers/cdm/__init__.py
@@ -1,10 +1,15 @@
-from flask import Blueprint
+# from flask import Blueprint
 
-cdm_bp = Blueprint("cdm", __name__, url_prefix="/cdm_api")
+# cdm_bp = Blueprint("cdm", __name__, url_prefix="/cdm_api")
 
-API_CATEGORY = "Cdm"
+# API_CATEGORY = "Cdm"
 
-from main.controllers.cdm.person import *
-from main.controllers.cdm.visit import *
+# swagger에서 Cdm 하나만 보이는게 불편하다.
+# 분리하는게 나을 것 같다.
+
+from main.controllers.cdm.person import person_bp
+from main.controllers.cdm.visit import visit_bp
 from main.controllers.cdm.concept import *
 from main.controllers.cdm.search import *
+
+cdm_bp = [person_bp, visit_bp]

--- a/main/controllers/cdm/__init__.py
+++ b/main/controllers/cdm/__init__.py
@@ -1,12 +1,3 @@
-# from flask import Blueprint
-
-# cdm_bp = Blueprint("cdm", __name__, url_prefix="/cdm_api")
-
-# API_CATEGORY = "Cdm"
-
-# swagger에서 Cdm 하나만 보이는게 불편하다.
-# 분리하는게 나을 것 같다.
-
 from main.controllers.cdm.person import person_bp
 from main.controllers.cdm.visit import visit_bp
 from main.controllers.cdm.concept import *

--- a/main/controllers/cdm/__init__.py
+++ b/main/controllers/cdm/__init__.py
@@ -1,6 +1,6 @@
-from main.controllers.cdm.person import person_bp
-from main.controllers.cdm.visit import visit_bp
 from main.controllers.cdm.concept import *
+from main.controllers.cdm.person import person_bp
 from main.controllers.cdm.search import *
+from main.controllers.cdm.visit import visit_bp
 
-cdm_bp = [person_bp, visit_bp]
+cdm_bps = [person_bp, visit_bp]

--- a/main/controllers/cdm/person.py
+++ b/main/controllers/cdm/person.py
@@ -1,7 +1,6 @@
+from flask import Blueprint
 from main.models.utils import convert_query_to_response
 from flask_apispec import marshal_with, doc
-# main에서 cdm 호출 후 cdm에서 person 호출
-from main.controllers.cdm import cdm_bp, API_CATEGORY
 from main import db
 from main.schema.cdm_schema import (
     PersonCount,
@@ -10,8 +9,12 @@ from main.schema.cdm_schema import (
 )
 from main.models.cdm_data import Death, Person
 
+person_bp = Blueprint("person", __name__, url_prefix="/person")
 
-@cdm_bp.route("/person", methods=["GET"])
+API_CATEGORY = "Person"
+
+
+@person_bp.route("/", methods=["GET"])
 @doc(tags=[API_CATEGORY],
      summary="컬럼 설명",
      description="환자 수 조회를 위한 파라미터를 설명합니다.")
@@ -25,7 +28,7 @@ def index():
   }, 200)
 
 
-@cdm_bp.route("/person/all", methods=["GET"])
+@person_bp.route("/all", methods=["GET"])
 @marshal_with(PersonCount, description="""
 <pre>
 person_count: 전체 환자 수
@@ -40,7 +43,7 @@ def all_count():
   }
 
 
-@cdm_bp.route("/person/gender", methods=["GET"])
+@person_bp.route("/gender", methods=["GET"])
 @doc(tags=[API_CATEGORY],
      summary="성별 환자 수 조회",
      description="성별 환자 수를 조회합니다.")
@@ -63,7 +66,7 @@ def gender_count():
   }
 
 
-@cdm_bp.route("/person/race", methods=["GET"])
+@person_bp.route("/race", methods=["GET"])
 @doc(tags=[API_CATEGORY],
      summary="인종별 환자 수 조회",
      description="인종별 환자 수를 조회합니다.")
@@ -85,7 +88,7 @@ def race_count():
   }
 
 
-@cdm_bp.route("/person/ethnicity", methods=["GET"])
+@person_bp.route("/ethnicity", methods=["GET"])
 @doc(tags=[API_CATEGORY],
      summary="민족별 환자 수 조회",
      description="민족별 환자 수를 조회합니다.")
@@ -111,7 +114,7 @@ def ethnicity_count():
   }
 
 
-@cdm_bp.route("/person/death", methods=["GET"])
+@person_bp.route("/death", methods=["GET"])
 @doc(tags=[API_CATEGORY],
      summary="사망 환자 수 조회",
      description="사망 환자 수를 조회합니다.")

--- a/main/controllers/cdm/person.py
+++ b/main/controllers/cdm/person.py
@@ -1,13 +1,13 @@
 from flask import Blueprint
 from flask_apispec import doc, marshal_with
 from main import db
+from main.models.cdm_data import Death, Person
+from main.models.utils import convert_query_to_response
 from main.schema.cdm_schema import (
     PersonCount,
     ResponseConceptPersonCount,
     ResponseSourcePersonCount
 )
-from main.models.cdm_data import Death, Person
-from main.models.utils import convert_query_to_response
 
 person_bp = Blueprint("person", __name__, url_prefix="/person")
 

--- a/main/controllers/cdm/person.py
+++ b/main/controllers/cdm/person.py
@@ -1,5 +1,5 @@
-from flask import Blueprint
 from main.models.utils import convert_query_to_response
+from flask import Blueprint
 from flask_apispec import marshal_with, doc
 from main import db
 from main.schema.cdm_schema import (
@@ -14,10 +14,12 @@ person_bp = Blueprint("person", __name__, url_prefix="/person")
 API_CATEGORY = "Person"
 
 
-@person_bp.route("/", methods=["GET"])
-@doc(tags=[API_CATEGORY],
-     summary="컬럼 설명",
-     description="환자 수 조회를 위한 파라미터를 설명합니다.")
+@person_bp.route("/index", methods=["GET"])
+@doc(
+    tags=[API_CATEGORY],
+    summary="컬럼 설명",
+    description="환자 수 조회를 위한 파라미터를 설명합니다."
+)
 def index():
   return ({
       "all": "모든 환자 수",
@@ -29,14 +31,19 @@ def index():
 
 
 @person_bp.route("/all", methods=["GET"])
-@marshal_with(PersonCount, description="""
-<pre>
-person_count: 전체 환자 수
-</pre>
-""")
-@doc(tags=[API_CATEGORY],
-     summary="전체 환자 수 조회",
-     description="전체 환자 수를 조회합니다.")
+@doc(
+    tags=[API_CATEGORY],
+    summary="전체 환자 수 조회",
+    description="전체 환자 수를 조회합니다."
+)
+@marshal_with(
+    PersonCount,
+    description="""
+    <pre>
+    person_count: 전체 환자 수
+    </pre>
+    """
+)
 def all_count():
   return {
       "person_count": db.session.query(Person).count()
@@ -44,18 +51,22 @@ def all_count():
 
 
 @person_bp.route("/gender", methods=["GET"])
-@doc(tags=[API_CATEGORY],
-     summary="성별 환자 수 조회",
-     description="성별 환자 수를 조회합니다.")
-@marshal_with(ResponseConceptPersonCount("person_list"),
-              description="""
-<pre>
-person_list: 환자 수 정보가 들어갈 리스트
-  .concept_id: 성별 Concept ID
-  .concept_name: 성별 Concept 이름
-  .person_count: 환자 수
-</pre>
-""")
+@doc(
+    tags=[API_CATEGORY],
+    summary="성별 환자 수 조회",
+    description="성별 환자 수를 조회합니다."
+)
+@marshal_with(
+    ResponseConceptPersonCount("person_list"),
+    description="""
+    <pre>
+    person_list: 환자 수 정보가 들어갈 리스트
+      .concept_id: 성별 Concept ID
+      .concept_name: 성별 Concept 이름
+      .person_count: 환자 수
+    </pre>
+    """
+)
 def gender_count():
   query = Person.person_gorup_by_condtion("gender_concept_id")
   return {
@@ -67,17 +78,22 @@ def gender_count():
 
 
 @person_bp.route("/race", methods=["GET"])
-@doc(tags=[API_CATEGORY],
-     summary="인종별 환자 수 조회",
-     description="인종별 환자 수를 조회합니다.")
-@marshal_with(ResponseConceptPersonCount("person_list"), description="""
-<pre>
-person_list: 환자 수 정보가 들어갈 리스트
-  .concept_id: 인종별 Concept ID
-  .concept_name: 인종별 Concept 이름
-  .person_count: 환자 수
-</pre>
-""")
+@doc(
+    tags=[API_CATEGORY],
+    summary="인종별 환자 수 조회",
+    description="인종별 환자 수를 조회합니다."
+)
+@marshal_with(
+    ResponseConceptPersonCount("person_list"),
+    description="""
+    <pre>
+    person_list: 환자 수 정보가 들어갈 리스트
+      .concept_id: 인종별 Concept ID
+      .concept_name: 인종별 Concept 이름
+      .person_count: 환자 수
+    </pre>
+    """
+)
 def race_count():
   query = Person.person_gorup_by_condtion("race_concept_id")
   return {
@@ -89,16 +105,21 @@ def race_count():
 
 
 @person_bp.route("/ethnicity", methods=["GET"])
-@doc(tags=[API_CATEGORY],
-     summary="민족별 환자 수 조회",
-     description="민족별 환자 수를 조회합니다.")
-@marshal_with(ResponseSourcePersonCount("person_list"), description="""
-<pre>
-person_list: 환자 수 정보가 들어갈 리스트
-  .source_value: 민족별 Source Value
-  .person_count: 환자 수
-</pre>
-""")
+@doc(
+    tags=[API_CATEGORY],
+    summary="민족별 환자 수 조회",
+    description="민족별 환자 수를 조회합니다."
+)
+@marshal_with(
+    ResponseSourcePersonCount("person_list"),
+    description="""
+    <pre>
+    person_list: 환자 수 정보가 들어갈 리스트
+      .source_value: 민족별 Source Value
+      .person_count: 환자 수
+    </pre>
+    """
+)
 def ethnicity_count():
   """
   ethnicitiy_concept_id의 모든 값이 0이다.
@@ -115,14 +136,19 @@ def ethnicity_count():
 
 
 @person_bp.route("/death", methods=["GET"])
-@doc(tags=[API_CATEGORY],
-     summary="사망 환자 수 조회",
-     description="사망 환자 수를 조회합니다.")
-@marshal_with(PersonCount, description="""
-<pre>
-person_count: 사망 환자 수
-</pre>
-""")
+@doc(
+    tags=[API_CATEGORY],
+    summary="사망 환자 수 조회",
+    description="사망 환자 수를 조회합니다."
+)
+@marshal_with(
+    PersonCount,
+    description="""
+    <pre>
+    person_count: 사망 환자 수
+    </pre>
+    """
+)
 def death_count():
   return {
       "person_count": db.session.query(Death).count()

--- a/main/controllers/cdm/person.py
+++ b/main/controllers/cdm/person.py
@@ -1,6 +1,5 @@
-from main.models.utils import convert_query_to_response
 from flask import Blueprint
-from flask_apispec import marshal_with, doc
+from flask_apispec import doc, marshal_with
 from main import db
 from main.schema.cdm_schema import (
     PersonCount,
@@ -8,6 +7,7 @@ from main.schema.cdm_schema import (
     ResponseSourcePersonCount
 )
 from main.models.cdm_data import Death, Person
+from main.models.utils import convert_query_to_response
 
 person_bp = Blueprint("person", __name__, url_prefix="/person")
 

--- a/main/controllers/cdm/visit.py
+++ b/main/controllers/cdm/visit.py
@@ -1,0 +1,159 @@
+from flask import Blueprint
+from main.models.utils import convert_query_to_response
+from flask_apispec import marshal_with, doc
+from main import db
+from main.schema.cdm_schema import (
+    VisitCount,
+    ResponseConceptVisitCount,
+    ResponseSourceVisitCount
+)
+from main.models.cdm_data import Visit
+
+visit_bp = Blueprint("visit", __name__, url_prefix="/visit")
+
+API_CATEGORY = "Visit"
+
+
+@visit_bp.route("/", methods=["GET"])
+@doc(tags=[API_CATEGORY],
+     summary="컬럼 설명",
+     description="방문 수 조회를 위한 파라미터를 설명합니다.")
+def index():
+  return ({
+      "all": "모든 방문 수",
+      "visit-type": "방문 유형(입원/외래/응급)별 방문 수",
+      "gender": "성별 방문 수",
+      "race": "인종별 방문 수",
+      "ethnicity": "민족별 방문 수",
+      "age-group": "방문시 연령대(10세 단위)별 방문 수"
+  }, 200)
+
+
+@visit_bp.route("/all", methods=["GET"])
+@marshal_with(VisitCount, description="""
+<pre>
+visit_count: 전체 방문 수
+</pre>
+""")
+@doc(tags=[API_CATEGORY],
+     summary="전체 방문 수 조회",
+     description="전체 방문 수를 조회합니다.")
+def all_count():
+  return {
+      "visit_count": db.session.query(Visit).count()
+  }
+
+
+@visit_bp.route("/visit-type", methods=["GET"])
+@marshal_with(ResponseConceptVisitCount("visit_list"),
+              description="""
+<pre>
+visit_list: 방문 수 정보가 들어갈 리스트
+  .concept_id: 방문 유형 Concept ID
+  .concept_name: 방문 유형 Concept 이름
+  .visit_count: 방문 수
+</pre>
+""")
+@doc(tags=[API_CATEGORY],
+     summary="방문 유형(입원/외래/응급)별 방문 수 조회",
+     description="방문 유형(입원/외래/응급)별 방문 수를 조회합니다.")
+def visit_type_count():
+  query = Visit.visit_gorup_by_visit_type()
+  return {
+      "visit_list": convert_query_to_response(
+          ("concept_id", "concept_name", "visit_count"),
+          query.all()
+      )
+  }
+
+
+@visit_bp.route("/gender", methods=["GET"])
+@doc(tags=[API_CATEGORY],
+     summary="성별 방문 수 조회",
+     description="성별 방문 수를 조회합니다.")
+@marshal_with(ResponseConceptVisitCount("visit_list"),
+              description="""
+<pre>
+visit_list: 방문 수 정보가 들어갈 리스트
+  .concept_id: 성별 Concept ID
+  .concept_name: 성별 Concept 이름
+  .visit_count: 방문 수
+</pre>
+""")
+def gender_count():
+  query = Visit.visit_gorup_by_condtion("gender_concept_id")
+  return {
+      "visit_list": convert_query_to_response(
+          ("concept_id", "concept_name", "visit_count"),
+          query.all()
+      )
+  }
+
+
+@visit_bp.route("/race", methods=["GET"])
+@doc(tags=[API_CATEGORY],
+     summary="인종별 방문 수 조회",
+     description="인종별 방문 수를 조회합니다.")
+@marshal_with(ResponseConceptVisitCount("visit_list"), description="""
+<pre>
+visit_list: 방문 수 정보가 들어갈 리스트
+  .concept_id: 인종별 Concept ID
+  .concept_name: 인종별 Concept 이름
+  .visit_count: 방문 수
+</pre>
+""")
+def race_count():
+  query = Visit.visit_gorup_by_condtion("race_concept_id")
+  return {
+      "visit_list": convert_query_to_response(
+          ("concept_id", "concept_name", "visit_count"),
+          query.all()
+      )
+  }
+
+
+@visit_bp.route("/ethnicity", methods=["GET"])
+@doc(tags=[API_CATEGORY],
+     summary="민족별 방문 수 조회",
+     description="민족별 방문 수를 조회합니다.")
+@marshal_with(ResponseSourceVisitCount("visit_list"), description="""
+<pre>
+visit_list: 방문 수 정보가 들어갈 리스트
+  .source_value: 민족별 Source Value
+  .visit_count: 방문 수
+</pre>
+""")
+def ethnicity_count():
+  """
+  ethnicitiy_concept_id의 모든 값이 0이다.
+  concept 테이블을 조회하니 유효하지 않는 값이라고 나온다.
+  부득이하게 대체 값인 ethnicity_source_value를 사용한다.
+  """
+  query = Visit.visit_group_by_ethnicity()
+  return {
+      "visit_list": convert_query_to_response(
+          ("source_value", "visit_count"),
+          query.all()
+      )
+  }
+
+
+@visit_bp.route("/age-group", methods=["GET"])
+@doc(tags=[API_CATEGORY],
+     summary="방문시 연령대(10세 단위)별 방문 수 조회",
+     description="방문시 연령대(10세 단위)별 방문 수를 조회합니다.")
+@marshal_with(ResponseSourceVisitCount("visit_list"), description="""
+<pre>
+visit_list: 방문 수 정보가 들어갈 리스트
+  .source_value: 방문시 연령대(10세 단위)
+  .visit_count: 방문 수
+</pre>
+""")
+def age_group_count():
+  query = Visit.visit_group_by_age_group()
+  return {
+      "visit_list": convert_query_to_response(
+          ("source_value", "visit_count"),
+          query.all()
+      )
+  }

--- a/main/controllers/cdm/visit.py
+++ b/main/controllers/cdm/visit.py
@@ -1,13 +1,13 @@
-from main.models.utils import convert_query_to_response
 from flask import Blueprint
-from flask_apispec import marshal_with, doc
+from flask_apispec import doc, marshal_with
 from main import db
+from main.models.cdm_data import Visit
+from main.models.utils import convert_query_to_response
 from main.schema.cdm_schema import (
     VisitCount,
     ResponseConceptVisitCount,
     ResponseSourceVisitCount
 )
-from main.models.cdm_data import Visit
 
 visit_bp = Blueprint("visit", __name__, url_prefix="/visit")
 

--- a/main/controllers/cdm/visit.py
+++ b/main/controllers/cdm/visit.py
@@ -1,5 +1,5 @@
-from flask import Blueprint
 from main.models.utils import convert_query_to_response
+from flask import Blueprint
 from flask_apispec import marshal_with, doc
 from main import db
 from main.schema.cdm_schema import (
@@ -14,10 +14,12 @@ visit_bp = Blueprint("visit", __name__, url_prefix="/visit")
 API_CATEGORY = "Visit"
 
 
-@visit_bp.route("/", methods=["GET"])
-@doc(tags=[API_CATEGORY],
-     summary="컬럼 설명",
-     description="방문 수 조회를 위한 파라미터를 설명합니다.")
+@visit_bp.route("/index", methods=["GET"])
+@doc(
+    tags=[API_CATEGORY],
+    summary="컬럼 설명",
+    description="방문 수 조회를 위한 파라미터를 설명합니다."
+)
 def index():
   return ({
       "all": "모든 방문 수",
@@ -35,9 +37,11 @@ def index():
 visit_count: 전체 방문 수
 </pre>
 """)
-@doc(tags=[API_CATEGORY],
-     summary="전체 방문 수 조회",
-     description="전체 방문 수를 조회합니다.")
+@doc(
+    tags=[API_CATEGORY],
+    summary="전체 방문 수 조회",
+    description="전체 방문 수를 조회합니다."
+)
 def all_count():
   return {
       "visit_count": db.session.query(Visit).count()
@@ -45,18 +49,22 @@ def all_count():
 
 
 @visit_bp.route("/visit-type", methods=["GET"])
-@marshal_with(ResponseConceptVisitCount("visit_list"),
-              description="""
-<pre>
-visit_list: 방문 수 정보가 들어갈 리스트
-  .concept_id: 방문 유형 Concept ID
-  .concept_name: 방문 유형 Concept 이름
-  .visit_count: 방문 수
-</pre>
-""")
-@doc(tags=[API_CATEGORY],
-     summary="방문 유형(입원/외래/응급)별 방문 수 조회",
-     description="방문 유형(입원/외래/응급)별 방문 수를 조회합니다.")
+@marshal_with(
+    ResponseConceptVisitCount("visit_list"),
+    description="""
+    <pre>
+    visit_list: 방문 수 정보가 들어갈 리스트
+      .concept_id: 방문 유형 Concept ID
+      .concept_name: 방문 유형 Concept 이름
+      .visit_count: 방문 수
+    </pre>
+    """
+)
+@doc(
+    tags=[API_CATEGORY],
+    summary="방문 유형(입원/외래/응급)별 방문 수 조회",
+    description="방문 유형(입원/외래/응급)별 방문 수를 조회합니다."
+)
 def visit_type_count():
   query = Visit.visit_gorup_by_visit_type()
   return {
@@ -68,18 +76,22 @@ def visit_type_count():
 
 
 @visit_bp.route("/gender", methods=["GET"])
-@doc(tags=[API_CATEGORY],
-     summary="성별 방문 수 조회",
-     description="성별 방문 수를 조회합니다.")
-@marshal_with(ResponseConceptVisitCount("visit_list"),
-              description="""
-<pre>
-visit_list: 방문 수 정보가 들어갈 리스트
-  .concept_id: 성별 Concept ID
-  .concept_name: 성별 Concept 이름
-  .visit_count: 방문 수
-</pre>
-""")
+@doc(
+    tags=[API_CATEGORY],
+    summary="성별 방문 수 조회",
+    description="성별 방문 수를 조회합니다."
+)
+@marshal_with(
+    ResponseConceptVisitCount("visit_list"),
+    description="""
+    <pre>
+    visit_list: 방문 수 정보가 들어갈 리스트
+      .concept_id: 성별 Concept ID
+      .concept_name: 성별 Concept 이름
+      .visit_count: 방문 수
+    </pre>
+    """
+)
 def gender_count():
   query = Visit.visit_gorup_by_condtion("gender_concept_id")
   return {
@@ -91,17 +103,22 @@ def gender_count():
 
 
 @visit_bp.route("/race", methods=["GET"])
-@doc(tags=[API_CATEGORY],
-     summary="인종별 방문 수 조회",
-     description="인종별 방문 수를 조회합니다.")
-@marshal_with(ResponseConceptVisitCount("visit_list"), description="""
-<pre>
-visit_list: 방문 수 정보가 들어갈 리스트
-  .concept_id: 인종별 Concept ID
-  .concept_name: 인종별 Concept 이름
-  .visit_count: 방문 수
-</pre>
-""")
+@doc(
+    tags=[API_CATEGORY],
+    summary="인종별 방문 수 조회",
+    description="인종별 방문 수를 조회합니다."
+)
+@marshal_with(
+    ResponseConceptVisitCount("visit_list"),
+    description="""
+    <pre>
+    visit_list: 방문 수 정보가 들어갈 리스트
+      .concept_id: 인종별 Concept ID
+      .concept_name: 인종별 Concept 이름
+      .visit_count: 방문 수
+    </pre>
+    """
+)
 def race_count():
   query = Visit.visit_gorup_by_condtion("race_concept_id")
   return {
@@ -113,16 +130,21 @@ def race_count():
 
 
 @visit_bp.route("/ethnicity", methods=["GET"])
-@doc(tags=[API_CATEGORY],
-     summary="민족별 방문 수 조회",
-     description="민족별 방문 수를 조회합니다.")
-@marshal_with(ResponseSourceVisitCount("visit_list"), description="""
-<pre>
-visit_list: 방문 수 정보가 들어갈 리스트
-  .source_value: 민족별 Source Value
-  .visit_count: 방문 수
-</pre>
-""")
+@doc(
+    tags=[API_CATEGORY],
+    summary="민족별 방문 수 조회",
+    description="민족별 방문 수를 조회합니다."
+)
+@marshal_with(
+    ResponseSourceVisitCount("visit_list"),
+    description="""
+    <pre>
+    visit_list: 방문 수 정보가 들어갈 리스트
+      .source_value: 민족별 Source Value
+      .visit_count: 방문 수
+    </pre>
+    """
+)
 def ethnicity_count():
   """
   ethnicitiy_concept_id의 모든 값이 0이다.
@@ -139,16 +161,21 @@ def ethnicity_count():
 
 
 @visit_bp.route("/age-group", methods=["GET"])
-@doc(tags=[API_CATEGORY],
-     summary="방문시 연령대(10세 단위)별 방문 수 조회",
-     description="방문시 연령대(10세 단위)별 방문 수를 조회합니다.")
-@marshal_with(ResponseSourceVisitCount("visit_list"), description="""
-<pre>
-visit_list: 방문 수 정보가 들어갈 리스트
-  .source_value: 방문시 연령대(10세 단위)
-  .visit_count: 방문 수
-</pre>
-""")
+@doc(
+    tags=[API_CATEGORY],
+    summary="방문시 연령대(10세 단위)별 방문 수 조회",
+    description="방문시 연령대(10세 단위)별 방문 수를 조회합니다."
+)
+@marshal_with(
+    ResponseSourceVisitCount("visit_list"),
+    description="""
+    <pre>
+    visit_list: 방문 수 정보가 들어갈 리스트
+      .source_value: 방문시 연령대(10세 단위)
+      .visit_count: 방문 수
+    </pre>
+    """
+)
 def age_group_count():
   query = Visit.visit_group_by_age_group()
   return {

--- a/main/controllers/skeleton.py
+++ b/main/controllers/skeleton.py
@@ -1,13 +1,6 @@
-from flask_apispec import use_kwargs, marshal_with, doc
-from main.controllers import skeleton_bp, API_CATEGORY
+from flask_apispec import doc, marshal_with, use_kwargs
+from main.controllers import API_CATEGORY, skeleton_bp
 from main.controllers.common.skeleton import check_test_id_exists
-from main.schema import RequestBodySchema, RequestParameterSchema, ResponseBodySchema
-from main.models.data import (
-    get_test_id_in_table,
-    insert_test_id_in_table,
-    update_test_id_in_table,
-    delete_test_id_in_table
-)
 from main.models.common.message import (
     ResponseMessage,
     ERROR_ID_NOT_EXISTS,
@@ -18,6 +11,13 @@ from main.models.common.message import (
     SUCCESS_ID_UPDATE,
     SUCCESS_ID_INSERT
 )
+from main.models.data import (
+    get_test_id_in_table,
+    insert_test_id_in_table,
+    update_test_id_in_table,
+    delete_test_id_in_table
+)
+from main.schema import RequestBodySchema, RequestParameterSchema, ResponseBodySchema
 
 
 @skeleton_bp.route("/skeleton", methods=["GET"])

--- a/main/models/cdm_data.py
+++ b/main/models/cdm_data.py
@@ -153,14 +153,16 @@ class Visit(db.Model):
 
   @classmethod
   def visit_group_by_age_group(cls):
+    age = cast(extract("year", cls.visit_start_date) - extract("year", Person.birth_datetime), Integer)
+    age_group = age / 10 * 10
     query = db.session.query(
-        (cast(extract("year", cls.visit_start_date) - extract("year", Person.birth_datetime), Integer) / 10) * 10,
+        age_group,
         func.count(cls.visit_occurrence_id)
     ).join(
         Person,
         Person.person_id == cls.person_id
     ).group_by(
-        (cast(extract("year", cls.visit_start_date) - extract("year", Person.birth_datetime), Integer) / 10) * 10
+        age_group
     )
     return query
 

--- a/main/models/cdm_data.py
+++ b/main/models/cdm_data.py
@@ -1,5 +1,5 @@
+from sqlalchemy import cast, func, extract, Integer
 from main import app, db
-from sqlalchemy import cast, Integer, func, extract
 
 
 # 생각해보니 굳이 Class가 아니어도 될 거 같긴 하다.
@@ -102,7 +102,6 @@ class Visit(db.Model):
   discharge_to_source_value = db.Column(db.String(50))
   discharge_to_concept_id = db.Column(db.Integer)
   preceding_visit_occurrence_id = db.Column(db.Integer)
-
 
   @classmethod
   def visit_gorup_by_visit_type(cls):

--- a/main/models/user.py
+++ b/main/models/user.py
@@ -1,10 +1,10 @@
 from datetime import datetime
-from werkzeug.security import generate_password_hash, check_password_hash
 from flask_jwt_extended import (
     create_access_token,
     create_refresh_token,
     decode_token
 )
+from werkzeug.security import check_password_hash, generate_password_hash
 from main import app, db
 
 

--- a/main/schema/cdm_schema.py
+++ b/main/schema/cdm_schema.py
@@ -6,6 +6,10 @@ class PersonCount(Schema):
   person_count = fields.Int(description="환자 수")
 
 
+class VisitCount(Schema):
+  visit_count = fields.Int(description="방문 수")
+
+
 class Concept(Schema):
   concept_id = fields.Int(description="Concept ID")
   concept_name = fields.Str(description="Concept 이름")
@@ -23,6 +27,14 @@ class SourcePersonCount(Source, PersonCount):
   pass
 
 
+class ConceptVisitCount(Concept, VisitCount):
+  pass
+
+
+class SourceVisitCount(Source, VisitCount):
+  pass
+
+
 def create_nested_list_schema(root_name, schema, name):
   return Schema.from_dict({
       root_name: fields.List(fields.Nested(schema))
@@ -31,15 +43,29 @@ def create_nested_list_schema(root_name, schema, name):
 
 def create_concept_person_count_list_schema(root_name):
   schema_name = root_name.split("_")[0].capitalize()
-  schema_name = f"Response{schema_name}PersonCount"
+  schema_name = f"Response{schema_name}Count"
   return create_nested_list_schema(root_name, ConceptPersonCount, schema_name)
 
 
 def create_source_person_count_list_schema(root_name):
   schema_name = root_name.split("_")[0].capitalize()
-  schema_name = f"Response{schema_name}PersonCount"
+  schema_name = f"Response{schema_name}Count"
   return create_nested_list_schema(root_name, SourcePersonCount, schema_name)
+
+
+def create_concept_visit_count_list_schema(root_name):
+  schema_name = root_name.split("_")[0].capitalize()
+  schema_name = f"Response{schema_name}Count"
+  return create_nested_list_schema(root_name, ConceptVisitCount, schema_name)
+
+
+def create_source_visit_count_list_schema(root_name):
+  schema_name = root_name.split("_")[0].capitalize()
+  schema_name = f"Response{schema_name}Count"
+  return create_nested_list_schema(root_name, SourceVisitCount, schema_name)
 
 
 ResponseConceptPersonCount = create_concept_person_count_list_schema
 ResponseSourcePersonCount = create_source_person_count_list_schema
+ResponseConceptVisitCount = create_concept_visit_count_list_schema
+ResponseSourceVisitCount = create_source_visit_count_list_schema


### PR DESCRIPTION
다음의 기능을 지원하는 visit class와 visit controller를 추가했습니다.

사용 가능한 URL 조회 (GET /api/visit)
전체 방문 수 조회 (GET /api/visit/all)
방문 유형(입원/외래/응급)별 방문 수 조회 (GET /api/visit/visit-type)
성별 방문 수 조회 (GET /api/visit/gender)
인종별 방문 수 조회 (GET /api/visit/race)
민족별 방문 수 조회 (GET /api/visit/ethnicity)
방문시 연령대(10세 단위)별 방문 수 조회 (GET /api/visit/age-group)

swagger에서 cdm tag 하나에 너무 많은 api가 붙어있는 것 같아
cdm_bp를 쪼개 person_bp, visit_bp로 나눴습니다.
앞으로도 쪼개서 작성할 것 같습니다.