### PR TITLE
feat(search): Search class 수정 및 search controller 개발

### DIFF
--- a/main/controllers/cdm/__init__.py
+++ b/main/controllers/cdm/__init__.py
@@ -1,6 +1,6 @@
 from main.controllers.cdm.concept import concept_bp
 from main.controllers.cdm.person import person_bp
-from main.controllers.cdm.search import *
+from main.controllers.cdm.search import search_bp
 from main.controllers.cdm.visit import visit_bp
 
-cdm_bps = [concept_bp, person_bp, visit_bp]
+cdm_bps = [concept_bp, person_bp, visit_bp, search_bp]

--- a/main/controllers/cdm/search.py
+++ b/main/controllers/cdm/search.py
@@ -1,0 +1,270 @@
+from flask import Blueprint
+from flask_apispec import doc, marshal_with, use_kwargs
+from main.models.cdm_data import (
+    Search,
+    Person,
+    Visit,
+    Drug,
+    Condition,
+    Death
+)
+from main.models.utils import convert_query_to_response
+from main.schema.cdm_schema import (
+    RequestTableSearch,
+    ResponseConceptSearchCount
+)
+
+search_bp = Blueprint("search", __name__, url_prefix="/search")
+
+API_CATEGORY = "Search"
+
+
+@search_bp.route("/index", methods=["GET"])
+@doc(
+    tags=[API_CATEGORY],
+    summary="테이블 설명",
+    description="조회가 가능한 테이블들을 설명합니다."
+)
+def index():
+  return ({
+      "person": {
+          "description": "person 테이블을 검색합니다.",
+          "target_column": ["gender", "race"]
+      },
+      "visit": {
+          "description": "visit_occurrence 테이블을 검색합니다.",
+          "target_column": ["visit", "visit-type"]
+      },
+      "condition": {
+          "description": "condition_occurrence 테이블을 검색합니다.",
+          "target_column": ["condition", "condition-type"]
+      },
+      "drug": {
+          "description": "drug_exposure 테이블을 검색합니다.",
+          "target_column": ["drug", "drug-type"]
+      },
+      "death": {
+          "description": "death 테이블을 검색합니다.",
+          "target_column": ["death-type"]
+      }
+  }, 200)
+
+
+@search_bp.route("/person", methods=["GET"])
+@doc(
+    tags=[API_CATEGORY],
+    summary="person 테이블 검색",
+    description="person 테이블의 target_column을 keyword로 검색합니다"
+)
+@marshal_with(
+    ResponseConceptSearchCount,
+    description="""
+    <pre>
+    list: keyword로 검색된 테이블 정보가 들어갈 리스트
+    </pre>
+    """
+)
+@use_kwargs(
+    RequestTableSearch,
+    location="query"
+)
+def person_keyword_search(page, length, target_column, keyword, order_key, desc):
+  query = Search.target_column_search(
+      table=Person,
+      target_col=f"{target_column}_concept_id",
+      keyword=keyword,
+      order_key=order_key,
+      desc=desc
+  ).slice((page - 1) * length, page * length)
+  return {
+      "list": convert_query_to_response(
+          (
+              "concept_id",
+              "concept_name",
+              "row_count"
+          ),
+          query.all(),
+          Person
+      ),
+      "target_column": target_column,
+      "keyword": keyword,
+      "page": page,
+      "order_key": order_key,
+      "desc": desc
+  }
+
+
+@search_bp.route("/visit", methods=["GET"])
+@doc(
+    tags=[API_CATEGORY],
+    summary="visit 테이블 검색",
+    description="visit 테이블의 target_column을 keyword로 검색합니다"
+)
+@marshal_with(
+    ResponseConceptSearchCount,
+    description="""
+    <pre>
+    list: keyword로 검색된 테이블 정보가 들어갈 리스트
+    </pre>
+    """
+)
+@use_kwargs(
+    RequestTableSearch,
+    location="query"
+)
+def visit_keyword_search(page, length, target_column, keyword, order_key, desc):
+  query = Search.target_column_search(
+      table=Visit,
+      target_col=f"{target_column}_concept_id",
+      keyword=keyword,
+      order_key=order_key,
+      desc=desc
+  ).slice((page - 1) * length, page * length)
+  return {
+      "list": convert_query_to_response(
+          (
+              "concept_id",
+              "concept_name",
+              "row_count"
+          ),
+          query.all(),
+          Visit
+      ),
+      "target_column": target_column,
+      "keyword": keyword,
+      "page": page,
+      "order_key": order_key,
+      "desc": desc
+  }
+
+
+@search_bp.route("/condition", methods=["GET"])
+@doc(
+    tags=[API_CATEGORY],
+    summary="condition 테이블 검색",
+    description="condition 테이블의 target_column을 keyword로 검색합니다"
+)
+@marshal_with(
+    ResponseConceptSearchCount,
+    description="""
+    <pre>
+    list: keyword로 검색된 테이블 정보가 들어갈 리스트
+    </pre>
+    """
+)
+@use_kwargs(
+    RequestTableSearch,
+    location="query"
+)
+def condition_keyword_search(page, length, target_column, keyword, order_key, desc):
+  query = Search.target_column_search(
+      table=Condition,
+      target_col=f"{target_column}_concept_id",
+      keyword=keyword,
+      order_key=order_key,
+      desc=desc
+  ).slice((page - 1) * length, page * length)
+  return {
+      "list": convert_query_to_response(
+          (
+              "concept_id",
+              "concept_name",
+              "row_count"
+          ),
+          query.all(),
+          Condition
+      ),
+      "target_column": target_column,
+      "keyword": keyword,
+      "page": page,
+      "order_key": order_key,
+      "desc": desc
+  }
+
+
+@search_bp.route("/drug", methods=["GET"])
+@doc(
+    tags=[API_CATEGORY],
+    summary="drug 테이블 검색",
+    description="drug 테이블의 target_column을 keyword로 검색합니다"
+)
+@marshal_with(
+    ResponseConceptSearchCount,
+    description="""
+    <pre>
+    list: keyword로 검색된 테이블 정보가 들어갈 리스트
+    </pre>
+    """
+)
+@use_kwargs(
+    RequestTableSearch,
+    location="query"
+)
+def drug_keyword_search(page, length, target_column, keyword, order_key, desc):
+  query = Search.target_column_search(
+      table=Drug,
+      target_col=f"{target_column}_concept_id",
+      keyword=keyword,
+      order_key=order_key,
+      desc=desc
+  ).slice((page - 1) * length, page * length)
+  return {
+      "list": convert_query_to_response(
+          (
+              "concept_id",
+              "concept_name",
+              "row_count"
+          ),
+          query.all(),
+          Drug
+      ),
+      "target_column": target_column,
+      "keyword": keyword,
+      "page": page,
+      "order_key": order_key,
+      "desc": desc
+  }
+
+
+@search_bp.route("/death", methods=["GET"])
+@doc(
+    tags=[API_CATEGORY],
+    summary="death 테이블 검색",
+    description="death 테이블의 target_column을 keyword로 검색합니다"
+)
+@marshal_with(
+    ResponseConceptSearchCount,
+    description="""
+    <pre>
+    list: keyword로 검색된 테이블 정보가 들어갈 리스트
+    </pre>
+    """
+)
+@use_kwargs(
+    RequestTableSearch,
+    location="query"
+)
+def death_keyword_search(page, length, target_column, keyword, order_key, desc):
+  query = Search.target_column_search(
+      table=Death,
+      target_col=f"{target_column}_concept_id",
+      keyword=keyword,
+      order_key=order_key,
+      desc=desc
+  ).slice((page - 1) * length, page * length)
+  return {
+      "list": convert_query_to_response(
+          (
+              "concept_id",
+              "concept_name",
+              "row_count"
+          ),
+          query.all(),
+          Death
+      ),
+      "target_column": target_column,
+      "keyword": keyword,
+      "page": page,
+      "order_key": order_key,
+      "desc": desc
+  }

--- a/main/schema/cdm_schema.py
+++ b/main/schema/cdm_schema.py
@@ -12,6 +12,10 @@ class RequestSearch(RequestPagination):
   desc = fields.Int(description="정렬 방식을 말합니다. (0: 오름차순, 1: 내림차순)", missing=0)
 
 
+class RequestTableSearch(RequestSearch):
+  target_column = fields.Str(description="검색할 컬럼입니다", required=True)
+
+
 # Response
 class PersonCount(Schema):
   person_count = fields.Int(description="환자 수")
@@ -33,6 +37,7 @@ class ConceptInfo(Schema):
   vocabulary_id = fields.Str()
   concept_class_id = fields.Str()
   standard_concept = fields.Str()
+  row_count = fields.Str()
 
 
 class Source(Schema):


### PR DESCRIPTION
Search class를 수정하고 search controller를 개발했습니다.

saerch controller는 특정 테이블에서 특정 컬럼의 값을 키워드로 검색할 수 있습니다.(like 검색)

GET /api/search/person
GET /api/search/visit
GET /api/search/condition
GET /api/search/drug
GET /api/search/death

person, visit_occurrence, condition_occurrence, drug, death 테이블에 대한 조회를 지원합니다.